### PR TITLE
Specify user.id in describe "profile page" (Listing 7.9)

### DIFF
--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -53,7 +53,7 @@ describe "User pages" do
     let!(:m1) { FactoryGirl.create(:micropost, user: user, content: "Foo") }
     let!(:m2) { FactoryGirl.create(:micropost, user: user, content: "Bar") }
 
-    before { visit user_path(user) }
+    before { visit user_path(user.id) }
 
     it { should have_content(user.name) }
     it { should have_title(user.name) }


### PR DESCRIPTION
Not specifying an id attempts to call the index of users, something that is not defined as of Listing 7.9 and, after the index is created in the controller and a matching view is made, will still fail the tests.
