### PR TITLE
No cookies patch

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -8,7 +8,11 @@ module SessionsHelper
   end
 
   def signed_in?
-    !current_user.nil?
+    if !cookies[:remember_token]
+      false
+    else
+      !current_user.nil?
+    end
   end
 
   def current_user=(user)


### PR DESCRIPTION
This patch was necessary when working through the tutorial to avoid "no implicit conversion of nil into String" errors in the current_user method if no cookies existed.
