### PR TITLE
Update Guardfile: changing after_all_pass to all_after_pass

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -15,7 +15,7 @@ guard 'spork', :cucumber_env => { 'RAILS_ENV' => 'test' },
   watch(%r{features/support/}) { :cucumber }
 end
 
-guard 'rspec', after_all_pass: false, cli: '--drb' do
+guard 'rspec', all_after_pass: false, cli: '--drb' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }


### PR DESCRIPTION
As discussed earlier, and according to the guard rspec documentation: ( https://github.com/guard/guard-rspec/blob/master/README.md ), "after_all_pass" should be replaced by "all_after_pass" in order to stop running all the specs after passing a particular spec file.
