### PR TITLE
fix routing of microposts - important only for submitting (POST) non valid microposts

### DIFF
--- a/app/views/shared/_micropost_form.html.erb
+++ b/app/views/shared/_micropost_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@micropost) do |f| %>
+<%= form_for(@micropost, url: root_path) do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="field">
     <%= f.text_area :content, placeholder: "Compose new micropost..." %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ SampleApp::Application.routes.draw do
   resources :microposts,    only: [:create, :destroy]
   resources :relationships, only: [:create, :destroy]
   root to: 'static_pages#home'
+  match '',         to: 'microposts#create',    via: :post
   match '/signup',  to: 'users#new',            via: 'get'
   match '/signin',  to: 'sessions#new',         via: 'get'
   match '/signout', to: 'sessions#destroy',     via: 'delete'


### PR DESCRIPTION
I noticed that the browser URL changes to /microposts when submitting an _empty_ micropost. Even though that is no biggie per se, the user will get a routing error if he/she were to submit that URL (e.g. localhost:3000/miproposts). 
Therefore, I found it useful to change 
- the routing of micrpost post requests
- the post URL within the micropost partial.
  accordingly.
