### PR TITLE
Improved test to catch nil and wrong user

### DIFF
--- a/spec/models/micropost_spec.rb
+++ b/spec/models/micropost_spec.rb
@@ -12,6 +12,8 @@ describe Micropost do
 
   it { should respond_to(:content) }
   it { should respond_to(:user_id) }
+  its (:user) { should == user }
+  it { should be_valid }
 
   describe "when user_id is not present" do
     before { @micropost.user_id = nil }


### PR DESCRIPTION
In case micropost user is nil, micropost spec still passes.
Also it doesn't check weather correct user got associated with micropost. Added two lines check these two conditions.
