### PR TITLE
Remove default scope on micropost

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,6 +1,5 @@
 class Micropost < ActiveRecord::Base
   belongs_to :user
-  default_scope -> { order('created_at DESC') }
   validates :content, presence: true, length: { maximum: 140 }
   validates :user_id, presence: true
 
@@ -9,6 +8,6 @@ class Micropost < ActiveRecord::Base
     followed_user_ids = "SELECT followed_id FROM relationships
                          WHERE follower_id = :user_id"
     where("user_id IN (#{followed_user_ids}) OR user_id = :user_id", 
-          user_id: user.id)
+          user_id: user.id).order('created_at DESC')
   end
 end


### PR DESCRIPTION
Call order method after calling where method without setting the default scope.
